### PR TITLE
Fixed Egg collisions in Module  02-01

### DIFF
--- a/Assets/Scenes/Module_02_01.unity
+++ b/Assets/Scenes/Module_02_01.unity
@@ -6474,7 +6474,7 @@ GameObject:
   m_Component:
   - component: {fileID: 185469993}
   - component: {fileID: 185469994}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -7318,7 +7318,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
@@ -7654,7 +7654,7 @@ GameObject:
   m_Component:
   - component: {fileID: 283450317}
   - component: {fileID: 283450318}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderOneFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -8054,7 +8054,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
@@ -9216,7 +9216,7 @@ GameObject:
   m_Component:
   - component: {fileID: 363129234}
   - component: {fileID: 363129235}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: Egg2_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -9649,7 +9649,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
@@ -9753,7 +9753,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
@@ -10973,7 +10973,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: f3b82b1a6222d49e3818fcf32630bafd,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: f3b82b1a6222d49e3818fcf32630bafd,
         type: 3}
@@ -11301,7 +11301,7 @@ GameObject:
   m_Component:
   - component: {fileID: 486160438}
   - component: {fileID: 486160439}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -11431,7 +11431,7 @@ PrefabInstance:
     - target: {fileID: 919132149155446097, guid: f3b82b1a6222d49e3818fcf32630bafd,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: f3b82b1a6222d49e3818fcf32630bafd,
         type: 3}
@@ -12112,7 +12112,7 @@ GameObject:
   m_Component:
   - component: {fileID: 531660569}
   - component: {fileID: 531660570}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: Egg2_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -12620,7 +12620,7 @@ GameObject:
   m_Component:
   - component: {fileID: 578694557}
   - component: {fileID: 578694558}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderThreeFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13460,7 +13460,7 @@ GameObject:
   m_Component:
   - component: {fileID: 681537548}
   - component: {fileID: 681537549}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -13859,7 +13859,7 @@ GameObject:
   m_Component:
   - component: {fileID: 732485846}
   - component: {fileID: 732485847}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderFourBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14522,7 +14522,7 @@ GameObject:
   m_Component:
   - component: {fileID: 816091767}
   - component: {fileID: 816091768}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: Egg2_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -14815,7 +14815,7 @@ GameObject:
   m_Component:
   - component: {fileID: 830444588}
   - component: {fileID: 830444589}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -15398,7 +15398,7 @@ GameObject:
   m_Component:
   - component: {fileID: 874553229}
   - component: {fileID: 874553230}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16055,7 +16055,7 @@ GameObject:
   m_Component:
   - component: {fileID: 916357495}
   - component: {fileID: 916357496}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: Egg2_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16611,7 +16611,7 @@ GameObject:
   - component: {fileID: 967708170}
   - component: {fileID: 967708169}
   - component: {fileID: 967708168}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: Sphere
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -16978,7 +16978,7 @@ GameObject:
   m_Component:
   - component: {fileID: 988745649}
   - component: {fileID: 988745650}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -17855,7 +17855,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 544
   m_InteractionLayers:
-    m_Bits: 544
+    m_Bits: 4640
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
@@ -17935,7 +17935,7 @@ MonoBehaviour:
   m_SphereCastRadius: 0
   m_RaycastMask:
     serializedVersion: 2
-    m_Bits: 544
+    m_Bits: 4640
   m_RaycastTriggerInteraction: 1
   m_HitClosestOnly: 0
   m_HoverToSelect: 0
@@ -18400,7 +18400,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e836c44c2da11ef4e9f40df9be6f459b,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e836c44c2da11ef4e9f40df9be6f459b,
         type: 3}
@@ -19077,7 +19077,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1130944333}
   - component: {fileID: 1130944334}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: Egg2_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19746,7 +19746,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1156258254}
   - component: {fileID: 1156258255}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: Egg1_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19836,7 +19836,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1170936615}
   - component: {fileID: 1170936616}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderFourFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -21642,7 +21642,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1306604348}
   - component: {fileID: 1306604349}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderOneBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -22520,7 +22520,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1364286534}
   - component: {fileID: 1364286535}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: CrackedEgg2_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24456,7 +24456,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1474368526}
   - component: {fileID: 1474368527}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -24515,7 +24515,7 @@ GameObject:
   - component: {fileID: 1481156690}
   - component: {fileID: 1481156689}
   - component: {fileID: 1481156688}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: Sphere
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -26262,8 +26262,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1597626089}
-  m_LocalRotation: {x: 0.29169735, y: 0.24183331, z: 0.07642499, w: -0.9222736}
-  m_LocalPosition: {x: -35.83546, y: -11.786575, z: -52.873764}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: -0.00000004371139}
+  m_LocalPosition: {x: -42.15924, y: -0.56999993, z: -35.91}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -26434,7 +26434,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1618340397}
   - component: {fileID: 1618340398}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -26806,7 +26806,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1662014675}
   - component: {fileID: 1662014676}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: CrackedEgg1_Arrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -27026,7 +27026,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1679040095}
   - component: {fileID: 1679040096}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -29160,7 +29160,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
@@ -29822,7 +29822,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1912535795}
   - component: {fileID: 1912535796}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderThreeBack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -30364,7 +30364,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e836c44c2da11ef4e9f40df9be6f459b,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e836c44c2da11ef4e9f40df9be6f459b,
         type: 3}
@@ -31163,7 +31163,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 544
   m_InteractionLayers:
-    m_Bits: 544
+    m_Bits: 4640
   m_AttachTransform: {fileID: 0}
   m_KeepSelectedTargetValid: 1
   m_StartingSelectedInteractable: {fileID: 0}
@@ -31243,7 +31243,7 @@ MonoBehaviour:
   m_SphereCastRadius: 0
   m_RaycastMask:
     serializedVersion: 2
-    m_Bits: 544
+    m_Bits: 4640
   m_RaycastTriggerInteraction: 1
   m_HitClosestOnly: 0
   m_HoverToSelect: 0
@@ -32540,7 +32540,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2044312799}
   - component: {fileID: 2044312800}
-  m_Layer: 9
+  m_Layer: 12
   m_Name: EggColliderTwoFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -33721,7 +33721,7 @@ PrefabInstance:
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}
       propertyPath: m_Layer
-      value: 9
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: e8d697062c91214479310cfa35291c72,
         type: 3}

--- a/Assets/XRI/Settings/Resources/InteractionLayerSettings.asset
+++ b/Assets/XRI/Settings/Resources/InteractionLayerSettings.asset
@@ -25,7 +25,7 @@ MonoBehaviour:
   - Interactable
   - 
   - 
-  - 
+  - Eggs
   - 
   - 
   - 

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 13
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -17,11 +18,12 @@ PhysicsManager:
   m_ClothInterCollisionDistance: 0
   m_ClothInterCollisionStiffness: 0
   m_ContactsGeneration: 1
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   m_AutoSimulation: 1
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
+  m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
   m_BroadphaseType: 0
   m_WorldBounds:
@@ -31,4 +33,6 @@ PhysicsManager:
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
   m_EnableUnifiedHeightmaps: 1
-  m_DefaultMaxAngluarSpeed: 7
+  m_ImprovedPatchFriction: 0
+  m_SolverType: 0
+  m_DefaultMaxAngularSpeed: 7

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 4
+  serializedVersion: 5
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -38,7 +38,7 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -32,7 +32,7 @@ TagManager:
   - Interactable
   - Placeholder
   - Walls
-  - 
+  - Eggs
   - 
   - 
   - 


### PR DESCRIPTION
Stopped Eggs from colliding in Module_02_01. 
- Added each egg to a "Eggs" layer
- Turned off Egg/Egg interactions under project settings in "Physics" and "Physics2D" 
- Added an "Eggs" interaction layer that is recognized by the "Dc Grab Interactable" script
- Under LeftHandController and RightHandController
            - Added "Eggs" interaction layer to "Interaction Layer Mask" 
            - Added "Eggs" layer to "Raycast Mask" to allow Raycast interaction

** Fix will need to be implemented in other areas with eggs such as Module_02_02